### PR TITLE
check of Key addresses exists

### DIFF
--- a/tooling.ipynb
+++ b/tooling.ipynb
@@ -479,7 +479,7 @@
     "    if item['blockheight'] > 498888:\n",
     "        continue\n",
     "    for i, output in enumerate(item['vout']):\n",
-    "        if output['scriptPubKey']['addresses'][0] in addrs:\n",
+    "        if 'addresses' in output['scriptPubKey'] and output['scriptPubKey']['addresses'][0] in addrs:\n",
     "            key = '{}:{}'.format(item['txid'],i)\n",
     "            unused[key] = {'txid':item['txid'], 'txindex':i, 'value':output['value'], 'script':output['scriptPubKey']['hex']}\n",
     "\n",


### PR DESCRIPTION
Hi Jimmy,

The ~~BTX~~ output fetcher chokes on OP_RETURN outputs (because they do not have the key 'addresses'). I have added a check to disregard those outputs.

Greetings,

Rik.

  