### PR TITLE
allow 15 byte hashes in script pub keys

### DIFF
--- a/helper.py
+++ b/helper.py
@@ -59,12 +59,14 @@ def decode_base58(s, num_bytes=25, strip_leading_zeros=False):
 
 def p2pkh_script(h160):
     '''Takes a hash160 and returns the scriptPubKey'''
-    return b'\x76\xa9\x14' + h160 + b'\x88\xac'
+    length = bytes([len(h160)])
+    return b'\x76\xa9' + length + h160 + b'\x88\xac'
 
 
 def p2sh_script(h160):
     '''Takes a hash160 and returns the scriptPubKey'''
-    return b'\xa9\x14' + h160 + b'\x87'
+    length = bytes([len(h160)])
+    return b'\xa9' + length + h160 + b'\x87'
 
 
 def read_varint(s):

--- a/helper_test.py
+++ b/helper_test.py
@@ -37,10 +37,20 @@ class HelperTest(TestCase):
     def test_p2pkh_script(self):
         h160 = unhexlify('74d691da1574e6b3c192ecfb52cc8984ee7b6c56')
         self.assertEqual(p2pkh_script(h160)[3:-2], h160)
+        
+    def test_long_p2pkh_script(self):
+        h160 = unhexlify('c45f1b548d1bc074828c415639b207a19cea1b5d4a')
+        expected = unhexlify('76a915c45f1b548d1bc074828c415639b207a19cea1b5d4a88ac')
+        self.assertEqual(p2pkh_script(h160), expected)
 
     def test_p2sh_script(self):
         h160 = unhexlify('74d691da1574e6b3c192ecfb52cc8984ee7b6c56')
         self.assertEqual(p2sh_script(h160)[2:-1], h160)
+        
+    def test_long_p2sh_script(self):
+        h160 = unhexlify('c45f1b548d1bc074828c415639b207a19cea1b5d4a')
+        expected = unhexlify('a915c45f1b548d1bc074828c415639b207a19cea1b5d4a87')
+        self.assertEqual(p2sh_script(h160), expected)
 
     def test_varint(self):
         tests = [


### PR DESCRIPTION
I was attempting to create some testnet transactions by hand and I kept running into a parsing error in `Script.parse(pubkey)`.

Turns out that I am attempting to send to an address which corresponds with a 21 byte hash, but the `p2pkh_script()` and `p2sh_script()` methods have a 20 byte length hard-coded in them. This was causing the last byte of the hash to either throw a key error or return nonsense from `Script.parse()`.